### PR TITLE
[team, personal] Dashboard 임시 페이지 생성 및 백엔드 연결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import GlobalThemeProvider from 'style/GlobalThemeProvider';
 import Survey from 'page/Survey';
 import Result from 'page/Result';
+import PersonalDashboard from 'page/Dashboard/Personal';
+import TeamDashboard from 'page/Dashboard/Team';
 import LoginPage from 'page/Login';
 import NotFound from 'page/NotFound';
 import { withAuthenticator } from 'aws-amplify-react';
@@ -14,6 +16,8 @@ function App() {
         <Switch>
           <Route exact path="/" component={withAuthenticator(Survey, false, [<LoginPage />])} />
           <Route exact path="/result" component={withAuthenticator(Result, false, [<LoginPage />])} />
+          <Route exact path="/dashboard/team" component={PersonalDashboard} />
+          <Route exact path="/dashboard/personal" component={TeamDashboard} />
           <Route path="*" component={NotFound} />
         </Switch>
       </Router>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,8 +16,8 @@ function App() {
         <Switch>
           <Route exact path="/" component={withAuthenticator(Survey, false, [<LoginPage />])} />
           <Route exact path="/result" component={withAuthenticator(Result, false, [<LoginPage />])} />
-          <Route exact path="/dashboard/team" component={PersonalDashboard} />
-          <Route exact path="/dashboard/personal" component={TeamDashboard} />
+          <Route exact path="/dashboard/team" component={TeamDashboard} />
+          <Route exact path="/dashboard/personal" component={PersonalDashboard} />
           <Route path="*" component={NotFound} />
         </Switch>
       </Router>

--- a/client/src/graphql/queries.ts
+++ b/client/src/graphql/queries.ts
@@ -12,6 +12,7 @@ export const getQuestionnaire = /* GraphQL */ `
     }
   }
 `;
+
 export const listQuestionnaires = /* GraphQL */ `
   query ListQuestionnaires($nextToken: String) {
     listQuestionnaires(nextToken: $nextToken) {

--- a/client/src/graphql/queries.ts
+++ b/client/src/graphql/queries.ts
@@ -43,3 +43,42 @@ export const getUser = /* GraphQL */ `
     }
   }
 `;
+
+export const listTeamDashboard = /* GraphQL */ `
+  query ListTeamDashboard($nextToken: String) {
+    listTeamDashboard(nextToken: $nextToken) {
+      items {
+        id
+        name
+        people
+        skills
+        outline
+        contents {
+          title
+          text
+        }
+      }
+      nextToken
+    }
+  }
+`;
+
+export const listPersonDashboard = /* GraphQL */ `
+  query ListPersonDashboard($nextToken: String) {
+    listPersonDashboard(nextToken: $nextToken) {
+      items {
+        id
+        name
+        skills
+        team
+        outline
+        domain
+        contents {
+          title
+          text
+        }
+      }
+      nextToken
+    }
+  }
+`;

--- a/client/src/page/Dashboard/Personal/index.tsx
+++ b/client/src/page/Dashboard/Personal/index.tsx
@@ -1,10 +1,46 @@
 import React from 'react';
+import { listPersonDashboard } from 'graphql/queries';
+import { gql, useQuery } from '@apollo/client';
 import * as S from './style';
 
-const PersonalDashboardPage = ({ className }: any) => (
-  <S.PersonalDashboardPage className={className}>
-    Personal Dashboard
-  </S.PersonalDashboardPage>
-);
+const PersonalDashboardPage = ({ className }: any) => {
+  const {
+    loading, error, data, refetch,
+  } = useQuery(gql`${listPersonDashboard}`);
+
+  if (loading) {
+    return <></>;
+  }
+
+  const temp = data.listPersonDashboard.items.map((el: any) => {
+    const skills = el.skills.map((skill: string) => (<div>{skill}</div>));
+    const contents = el.contents.map((content: any) => (
+      <div>
+        <div>title : {content.title}</div>
+        <div>text: {content.text}</div>
+      </div>
+    ));
+    return (
+
+      <div>
+        <div>name: {el.name}</div>
+        <div>outline: {el.outline}</div>
+        <div>skills: {skills}</div>
+        <div>team: {el.team}</div>
+        <div>contents: {contents}</div>
+        <div>domain: {el.domain}</div>
+      </div>
+    );
+  });
+
+  return (
+    <S.PersonalDashboardPage className={className}>
+      Personal Dashboard
+      <div>
+        {temp}
+      </div>
+    </S.PersonalDashboardPage>
+  );
+};
 
 export default PersonalDashboardPage;

--- a/client/src/page/Dashboard/Personal/index.tsx
+++ b/client/src/page/Dashboard/Personal/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import * as S from './style';
+
+const PersonalDashboardPage = ({ className }: any) => (
+  <S.PersonalDashboardPage className={className}>
+    Personal Dashboard
+  </S.PersonalDashboardPage>
+);
+
+export default PersonalDashboardPage;

--- a/client/src/page/Dashboard/Personal/style.ts
+++ b/client/src/page/Dashboard/Personal/style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const PersonalDashboardPage = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export default {};

--- a/client/src/page/Dashboard/Team/index.tsx
+++ b/client/src/page/Dashboard/Team/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import * as S from './style';
+
+const TeamDashboardPage = ({ className }: any) => (
+  <S.TeamDashboardPage className={className}>
+    TEAM Dashboard
+  </S.TeamDashboardPage>
+);
+
+export default TeamDashboardPage;

--- a/client/src/page/Dashboard/Team/index.tsx
+++ b/client/src/page/Dashboard/Team/index.tsx
@@ -1,10 +1,45 @@
 import React from 'react';
+import { listTeamDashboard } from 'graphql/queries';
+import { gql, useQuery } from '@apollo/client';
 import * as S from './style';
 
-const TeamDashboardPage = ({ className }: any) => (
-  <S.TeamDashboardPage className={className}>
-    TEAM Dashboard
-  </S.TeamDashboardPage>
-);
+const TeamDashboardPage = ({ className }: any) => {
+  const {
+    loading, error, data, refetch,
+  } = useQuery(gql`${listTeamDashboard}`);
+
+  if (loading) {
+    return <></>;
+  }
+  const temp = data.listTeamDashboard.items.map((el: any) => {
+    const people = el.people.map((person: string) => (
+      <div>{person}</div>
+    ));
+    const skills = el.skills.map((skill: string) => (
+      <div>{skill}</div>
+    ));
+    const contents = el.contents.map((content: any) => (
+      <div>
+        <div>title : {content.title}</div>
+        <div>text : {content.text}</div>
+      </div>
+    ));
+    return (
+      <div>
+        <div>name : {el.name}</div>
+        <div>person: {people}</div>
+        <div>skills: {skills}</div>
+        <div>contents: {contents}</div>
+      </div>
+    );
+  });
+  return (
+    <S.TeamDashboardPage className={className}>
+      TEAM Dashboard
+      {temp}
+    </S.TeamDashboardPage>
+
+  );
+};
 
 export default TeamDashboardPage;

--- a/client/src/page/Dashboard/Team/style.ts
+++ b/client/src/page/Dashboard/Team/style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const TeamDashboardPage = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export default {};


### PR DESCRIPTION
## 변경사항

* team, personal 현황판 페이지를 임시로 만들고 라우팅 했습니다.
* 백엔드에서 데이터 가져올 수 있도록 했습니다.

## 백엔드 관련 참고할 문서

[노션 링크에서 personDashboard 참고](https://www.notion.so/LCTP-15995f7354554a4da4b4070e2654b3aa)
teamDashboard는 personDashboard 설명서 참고해서 하면 됩니다.

