### PR TITLE
매칭 대기열 페이지 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,6 +32,7 @@ function App() {
             component={PersonalDashboard}
           />
           <Route exact path="/matching" component={Matching} />
+          <Route exact path="/login" component={LoginPage} />
           <Route path="*" component={NotFound} />
         </Switch>
       </Router>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import PersonalDashboard from 'page/Dashboard/Personal';
 import TeamDashboard from 'page/Dashboard/Team';
 import LoginPage from 'page/Login';
 import NotFound from 'page/NotFound';
+import Matching from 'page/Matching';
 import { withAuthenticator } from 'aws-amplify-react';
 
 function App() {
@@ -14,10 +15,23 @@ function App() {
     <GlobalThemeProvider>
       <Router>
         <Switch>
-          <Route exact path="/" component={withAuthenticator(Survey, false, [<LoginPage />])} />
-          <Route exact path="/result" component={withAuthenticator(Result, false, [<LoginPage />])} />
+          <Route
+            exact
+            path="/"
+            component={withAuthenticator(Survey, false, [<LoginPage />])}
+          />
+          <Route
+            exact
+            path="/result"
+            component={withAuthenticator(Result, false, [<LoginPage />])}
+          />
           <Route exact path="/dashboard/team" component={TeamDashboard} />
-          <Route exact path="/dashboard/personal" component={PersonalDashboard} />
+          <Route
+            exact
+            path="/dashboard/personal"
+            component={PersonalDashboard}
+          />
+          <Route exact path="/matching" component={Matching} />
           <Route path="*" component={NotFound} />
         </Switch>
       </Router>

--- a/client/src/graphql/queries.ts
+++ b/client/src/graphql/queries.ts
@@ -33,11 +33,11 @@ export const getUser = /* GraphQL */ `
     getUser {
       items {
         id
-        userId 
+        userId
         question {
           title
           answers
-        }  
+        }
         owner
       }
     }
@@ -77,6 +77,23 @@ export const listPersonDashboard = /* GraphQL */ `
           title
           text
         }
+      }
+      nextToken
+    }
+  }
+`;
+
+export const listMatchWaitQueue = `
+  query listMatchWaitQueue($nextToken: String) {
+    listMatchWaitQueue(nextToken: $nextToken) {
+      items {
+        id
+        type
+        name
+        year
+        stacks
+        message
+        state
       }
       nextToken
     }

--- a/client/src/page/Matching/MatchContainer.tsx
+++ b/client/src/page/Matching/MatchContainer.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable */
+import React from 'react';
+import { listMatchWaitQueue } from '../../graphql/queries';
+import { gql, useQuery } from '@apollo/client';
+
+import MatchPresenter from './MatchPresenter';
+
+const MatchWaitQueue = ({ className }: any) => {
+  const { loading, error, data, refetch } = useQuery(
+    gql`
+      ${listMatchWaitQueue}
+    `,
+  );
+  if (loading) {
+    return <></>;
+  }
+  console.log(data);
+  return <MatchPresenter className={className} data={data} />;
+};
+
+export default MatchWaitQueue;

--- a/client/src/page/Matching/MatchPresenter.tsx
+++ b/client/src/page/Matching/MatchPresenter.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import * as S from './style';
+
+const MatchPresenter = ({
+  className,
+  data,
+}: {
+  className: string;
+  data: any;
+}) => {
+  const { items } = data.listMatchWaitQueue;
+  const temp = items.map((el: any) => {
+    const stacks = el.stacks.map((stack: string) => <S.Text>{stack}</S.Text>);
+    return (
+      <S.List>
+        <S.Text>{el.name}</S.Text>
+        <S.Text>{el.year}</S.Text>
+        <S.Stack>{stacks}</S.Stack>
+        <S.Text>{el.message}</S.Text>
+        <S.Text>{el.state}</S.Text>
+      </S.List>
+    );
+  });
+  return (
+    <S.MatchPage className={className}>
+      <S.Title>매칭 대기열</S.Title>
+      <S.Title>Front-End</S.Title>
+      {temp}
+    </S.MatchPage>
+  );
+};
+export default MatchPresenter;

--- a/client/src/page/Matching/index.tsx
+++ b/client/src/page/Matching/index.tsx
@@ -1,0 +1,3 @@
+import MatchContainer from './MatchContainer';
+
+export default MatchContainer;

--- a/client/src/page/Matching/style.ts
+++ b/client/src/page/Matching/style.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const MatchPage = styled.div`
+  margin-top: 10%;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+`;
+export const Title = styled.h1`
+  font-size: 40px;
+  margin-bottom: 50px;
+`;
+
+export const Text = styled.div`
+  font-size: 20px;
+`;
+export const Stack = styled.div`
+  width: 150px;
+  display: flex;
+  justify-content: space-around;
+`;
+
+export const List = styled.div`
+  display: flex;
+  width: 1000px;
+  margin-bottom: 30px;
+  justify-content: space-between;
+`;
+export default {};


### PR DESCRIPTION
- AWS AppSync의 Data Sources matchWaitQueue추가
- DynamoDb matchWaitQueue table 추가
- graphql - queries.ts에 listMatchWaitQueue(AWS AppSync의 Schema) 추가
- Matching page 추가하고 DB정보 page에 표시
- App.tsx에 react-router /matching 추가