### PR TITLE
Display added data on detailModal #29

### DIFF
--- a/client/src/component/atoms/TextLabel/index.stories.tsx
+++ b/client/src/component/atoms/TextLabel/index.stories.tsx
@@ -32,3 +32,20 @@ export const Outline = () => (
     <Template outline text="Orange" color='orange' />
   </div>
 );
+
+export const FontColors = () => (
+  <div>
+    <Template text="Default" />
+    <Template text="Gray" fontColor='gray' />
+    <Template text="Red" fontColor='red' />
+    <Template text="Green" fontColor='green' />
+  </div>
+);
+
+export const TeamState = () => (
+  <div>
+    <Template text="Default" fontColor='gray' color='gray' />
+    <Template text="모집중" fontColor='green' color='green' />
+    <Template text="진행중" fontColor='red' color='red' />
+  </div>
+);

--- a/client/src/component/atoms/TextLabel/style.ts
+++ b/client/src/component/atoms/TextLabel/style.ts
@@ -3,6 +3,7 @@ import globalTheme from 'style/theme';
 
 export interface StyleProps {
   color?: keyof typeof globalTheme.color.label;
+  fontColor?: keyof typeof globalTheme.color.text;
   outline?: boolean;
 }
 
@@ -24,6 +25,14 @@ const colorStyle = css<StyleProps>`
 }
 `;
 
+const fontColorStyle = css<StyleProps>`
+  ${({ theme, fontColor = 'black' }) => {
+    const selected = theme.color.text[fontColor];
+    return fontColor && css`color: ${selected};`;
+  }
+}
+`;
+
 export const TextLabel = styled.div<StyleProps>`
   display: inline-block;
   font-size: 1rem;
@@ -33,6 +42,8 @@ export const TextLabel = styled.div<StyleProps>`
   border-radius: 2.5em;
 
   ${colorStyle}
+
+  ${fontColorStyle}
 `;
 
 export const Text = styled.span`

--- a/client/src/component/orgamisms/DetailModal/Personal/index.stories.tsx
+++ b/client/src/component/orgamisms/DetailModal/Personal/index.stories.tsx
@@ -7,7 +7,8 @@ const props = {
     id: 'bbbbb',
     name: '테스트계정',
     outline: '열심히 하겠습니다',
-    domain: 'Backend',
+    devExp: '1년',
+    field: 'Backend',
     skills: ['React', 'MongoDB', 'Express'],
     team: ['팀 구하는중'],
     contents: [

--- a/client/src/component/orgamisms/DetailModal/Personal/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Personal/index.tsx
@@ -8,7 +8,8 @@ export interface PersonalModalProps {
     id: string;
     name: string;
     outline: string;
-    domain: string;
+    field: string;
+    devExp: string;
     skills: string[];
     team: string[];
     contents: ContentItem[];
@@ -63,7 +64,7 @@ const PersonalDetailModal = ({ data, onCloseModal }: PersonalModalProps) => {
     data ? <DetailModalTemplate
       modalHeader={
         <>
-          <S.Domain>{data.domain}</S.Domain>
+          <S.Domain>{`${data.field} ${data.devExp}`}</S.Domain>
           <S.Title type="personal">{data.name}</S.Title>
           <S.Desc>{data.outline}</S.Desc>
         </>

--- a/client/src/component/orgamisms/DetailModal/Team/index.stories.tsx
+++ b/client/src/component/orgamisms/DetailModal/Team/index.stories.tsx
@@ -26,6 +26,7 @@ const props = {
         vulputate quisque facilisis lorem aenean felis nullam, sodales habitant nunc tempor etiam. Lacus imperdiet tellus commodo molestie luctus vitae euismod ad est cubilia lacinia sagittis, suscipit eleifend aliquet ornare fringilla consequat ridiculus sem justo conubia.`,
       },
     ],
+    state: '모집중',
   },
   onCloseModal: () => alert('close'),
 };

--- a/client/src/component/orgamisms/DetailModal/Team/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Team/index.tsx
@@ -11,6 +11,7 @@ export interface TeamModalProps {
     outline: string;
     contents: ContentItem[];
     skills: string[];
+    state: string;
   };
   onCloseModal: () => void;
 }
@@ -68,6 +69,7 @@ const TeamDetailModal = ({ data, onCloseModal }: TeamModalProps) => {
     <DetailModalTemplate
       modalHeader={
         <>
+          <S.State text={data?.state || ''} />
           <S.Title type="team">{data?.name}</S.Title>
           <S.Desc>{data?.outline}</S.Desc>
         </>

--- a/client/src/component/orgamisms/DetailModal/TeamAddForm/index.stories.tsx
+++ b/client/src/component/orgamisms/DetailModal/TeamAddForm/index.stories.tsx
@@ -1,5 +1,4 @@
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
-import client from 'Apollo';
 import React from 'react';
 import GlobalThemeProvider from 'style/GlobalThemeProvider';
 import TeamAddForm from '.';
@@ -11,6 +10,7 @@ const props = {
     people: ['user1', 'user2', 'user3', 'user4', 'user5', 'user6'],
     skills: ['React', 'MongoDB', 'GraphQL', 'Apollo Client'],
     outline: '한줄 소개 입니다.',
+    state: '',
     contents: [
       {
         title: '구현하고자 하는 것',

--- a/client/src/component/orgamisms/DetailModal/style.ts
+++ b/client/src/component/orgamisms/DetailModal/style.ts
@@ -185,3 +185,28 @@ export const Textarea = styled(InputText)`
     margin-right: 0.2em;
   }
 `;
+
+const setColor = (text: string) => {
+  switch (text) {
+  case '모집중':
+    return 'green';
+  case '진행중':
+    return 'red';
+  case '종료':
+    return 'gray';
+  default:
+    return undefined;
+  }
+};
+
+export const State = styled((props: { text: string }) => _TextLabel({
+  color: setColor(props.text),
+  fontColor: setColor(props.text),
+  ...props,
+}))`
+  font-size: 1.2rem;
+  font-weight: bold;
+  padding: 0.7em 0.8em;
+  line-height: 1em;
+  margin-bottom: 0.8em;
+`;

--- a/client/src/page/Dashboard/Team/index.tsx
+++ b/client/src/page/Dashboard/Team/index.tsx
@@ -51,7 +51,7 @@ const TeamDashboardPage = ({ className }: any) => {
           <Personal.Stack>{skills}</Personal.Stack>
           <Team.Content>{contents}</Team.Content>
         </Team.Left>
-        <Team.State state={team.state}>{team.state}</Team.State>
+        <Team.State text={team.state}/>
       </Team.List>
     );
   });

--- a/client/src/page/Dashboard/Team/style.ts
+++ b/client/src/page/Dashboard/Team/style.ts
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+import globalTheme from 'style/theme';
+import TextLabel from 'component/atoms/TextLabel';
 
 export const TeamDashboardPage = styled.div`
   height: 100%;
@@ -35,48 +37,22 @@ export const ContentInfo = styled.div`
 `;
 
 export interface stateProps {
+  theme: typeof globalTheme;
   state: '모집중' | '진행중' | '종료';
 }
 
-export const State = styled.div`
-  border-radius: 2rem;
-  background-color:${({ state }: stateProps) => {
-    let backGroundColor;
-    switch (state) {
-    case '모집중':
-      backGroundColor = '#D1F3DB';
-      break;
-    case '진행중':
-      backGroundColor = '#F3DFDE';
-      break;
-    default:
-      backGroundColor = '#E7EAEC';
-      break;
-    }
-    return backGroundColor;
-  }};
-
-  padding: 0.7em 0.8em;
-
-  color: ${({ state }: stateProps) => {
-    let fontColor;
-    switch (state) {
-    case '모집중':
-      fontColor = '#2AC551';
-      break;
-    case '진행중':
-      fontColor = '#E55052';
-      break;
-    default:
-      fontColor = '#657381';
-      break;
-    }
-    return fontColor;
-  }};
-
-  font-size: 1.6rem;
-  font-weight: bold;
-`;
+const setColor = (text: string) => {
+  switch (text) {
+  case '모집중':
+    return 'green';
+  case '진행중':
+    return 'red';
+  case '종료':
+    return 'gray';
+  default:
+    return undefined;
+  }
+};
 
 export const Main = styled.h1`
   margin: 1.5em 0;
@@ -133,4 +109,17 @@ export const CreateBtn = styled.button`
   font-size: 2rem;
   border-radius: 0.5rem;
 `;
+
+export const State = styled((props: { text: string }) => TextLabel({
+  color: setColor(props.text),
+  fontColor: setColor(props.text),
+  ...props,
+}))`
+  font-size: 1.6rem;
+  font-weight: bold;
+  padding: 0.7em 0.8em;
+  line-height: 1em;
+  margin-bottom: 0.8em;
+`;
+
 export default {};

--- a/client/src/style/theme.ts
+++ b/client/src/style/theme.ts
@@ -13,7 +13,12 @@ const color = {
   delete: '#DC3545',
   deleteHover: '#C82333',
   background: '#FCFDFF',
-  text: '#271B31',
+  text: {
+    black: '#271B31',
+    gray: '#657381',
+    green: '#2AC551',
+    red: '#E55052',
+  },
   scrollbar: '#dedede',
   button: {
     red: '#FF5C6A',
@@ -23,11 +28,13 @@ const color = {
     orange: '#FFB38F',
   },
   label: {
-    gray: '#DFDDE5',
-    red: '#E88073',
+    gray: '#E7EAEC',
+    darkRed: '#E88073',
     blue: '#DFF3F0',
     yellow: '#F7EAA0',
     orange: '#FFB38F',
+    green: '#D1F3DB',
+    red: '#F3DFDE',
   },
   shadowscale: ['5px 5px 12px rgba(0,0,0,0.25)'],
 };


### PR DESCRIPTION
- Personal `DetailModal`에 `devExp` 정보 표시
<img src="https://user-images.githubusercontent.com/64844815/122329891-28edf380-cf6d-11eb-9bde-38cc948d5d99.png" width="300" alt="personal">

- Team `DetailModal`에 `state` 정보 표시
<img src="https://user-images.githubusercontent.com/64844815/122329930-386d3c80-cf6d-11eb-9a19-1942db36d6be.png" width="300" alt="team">

close #29 