### PR TITLE
Feat: Change auth type based on the login status #41

### DIFF
--- a/client/src/Apollo.ts
+++ b/client/src/Apollo.ts
@@ -3,20 +3,40 @@ import { createAuthLink } from 'aws-appsync-auth-link';
 import { createHttpLink } from 'apollo-link-http';
 import { AUTH_TYPE } from 'aws-appsync';
 import { ApolloClient, InMemoryCache } from '@apollo/client';
-import appSyncConfig from 'aws-exports';
+import appSyncConfig, { apiKey } from 'aws-exports';
 import Amplify, { Auth } from 'aws-amplify';
 
 Amplify.configure(appSyncConfig);
 
 const url = appSyncConfig.aws_appsync_graphqlEndpoint;
 const region = appSyncConfig.aws_appsync_region;
-const auth = {
-  type: appSyncConfig.aws_appsync_authenticationType as AUTH_TYPE,
-  jwtToken: async () => (await Auth.currentSession()).getIdToken().getJwtToken(),
-};
+const authenticationType = ['AMAZON_COGNITO_USER_POOLS', 'API_KEY'];
+
+const apiAuthLink = createAuthLink({
+  url,
+  region,
+  auth: {
+    type: authenticationType[1] as AUTH_TYPE.API_KEY,
+    apiKey,
+  },
+}) as any;
+
+const tokenAuthLink = createAuthLink({
+  url,
+  region,
+  auth: {
+    type: authenticationType[0] as AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+    jwtToken: async () => (await Auth.currentSession()).getIdToken().getJwtToken(),
+  },
+}) as any;
+
+const awsLink = ApolloLink.split((operation) => {
+  const publicOperations = ['ListPersonDashboard', 'ListTeamDashboard'];
+  return publicOperations.includes(operation.operationName);
+}, apiAuthLink, tokenAuthLink);
 
 const link = ApolloLink.from([
-  createAuthLink({ url, region, auth } as any) as any,
+  awsLink,
   createHttpLink({ uri: url }),
 ]);
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import GlobalThemeProvider from 'style/GlobalThemeProvider';
 import Survey from 'page/Survey';
@@ -8,8 +8,15 @@ import TeamDashboard from 'page/Dashboard/Team';
 import LoginPage from 'page/Login';
 import NotFound from 'page/NotFound';
 import { withAuthenticator } from 'aws-amplify-react';
+import { Auth } from 'aws-amplify';
 
 function App() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  Auth.currentAuthenticatedUser()
+    .then(() => setIsLoggedIn(true))
+    .catch(() => setIsLoggedIn(false));
+
   return (
     <GlobalThemeProvider>
       <Router>
@@ -24,7 +31,9 @@ function App() {
             path="/result"
             component={withAuthenticator(Result, false, [<LoginPage />])}
           />
-          <Route exact path="/dashboard/team" component={TeamDashboard} />
+          <Route exact path="/dashboard/team">
+            <TeamDashboard isLoggedIn={isLoggedIn} />
+          </Route>
           <Route
             exact
             path="/dashboard/personal"

--- a/client/src/page/Dashboard/Team/index.tsx
+++ b/client/src/page/Dashboard/Team/index.tsx
@@ -15,7 +15,7 @@ interface ModalState {
   data?: TeamData;
 }
 
-const TeamDashboardPage = ({ className }: any) => {
+const TeamDashboardPage = ({ className, isLoggedIn }: any) => {
   const [modal, setModal] = useState<ModalState>({});
 
   const {
@@ -81,7 +81,7 @@ const TeamDashboardPage = ({ className }: any) => {
           <Team.Main>팀 현황판</Team.Main>
         </Personal.Top>
         <Team.TeamPage>{teams}</Team.TeamPage>
-        <Team.CreateBtn onClick={() => setModal({ type: 'add' })}>팀 생성하기</Team.CreateBtn>
+        {isLoggedIn && <Team.CreateBtn onClick={() => setModal({ type: 'add' })}>팀 생성하기</Team.CreateBtn>}
       </Personal.Container>
     </BaseTemplate>
   );


### PR DESCRIPTION
- Change auth type for queries related of dashboard
![Change auth type](https://user-images.githubusercontent.com/64844815/124603305-c1a8cc80-dea4-11eb-8da0-a103acfcd70b.gif)

- Display or not the team add button based on login status on TeamDashboard

|Logged in|Not Logged in|
|:-:|:-:|
|![Logged in](https://user-images.githubusercontent.com/64844815/124603143-94f4b500-dea4-11eb-89fa-2a3254a7b68c.png)|![Not logged in](https://user-images.githubusercontent.com/64844815/124603070-83131200-dea4-11eb-96db-684aafc892d7.png)|

## 참고 사항
- Appsync에서 생성한 ApiKey의 최대 연장기간은 1년입니다.
- 이 방법은 dashboard에서 데이터 조회 요청을 영구적으로 public 하게 만드는 방법은 아닙니다.
- 찾아본 바로는, 현재 AWS Appsync에서는 ApiKey와 IAM 두 가지 방식으로만 public한 권한으로 요청을 보낼 수 있다고 합니다.
- Apikey 자동 생성 및 연장 혹은 IAM에 대해 찾아보시면 아래 처럼 1년마다 수동으로 ApiKey를 새로 만들고 변경하는 작업을 하지 않을 수 있을 것 같습니다.

## 세팅 방법
Appsync Schema 아래와 같이 변경

```
type Query {
	...
	listTeamDashboard(nextToken: String): teamDashbaord_Connection **@aws_api_key @aws_cognito_user_pools**
	listPersonDashboard(nextToken: String): personDashboard_Connection **@aws_api_key @aws_cognito_user_pools**
}

type dashboardContent **@aws_api_key @aws_cognito_user_pools** {
	...
}

type personDashboard **@aws_api_key @aws_cognito_user_pools** {
	...
}

type personDashboard_Connection **@aws_api_key @aws_cognito_user_pools** {
	...
}

type teamDashbaord_Connection **@aws_api_key @aws_cognito_user_pools** {
	...
}

type teamDashboard **@aws_api_key @aws_cognito_user_pools** {
	...
}
```

Appsync settings 클릭
![settings](https://user-images.githubusercontent.com/64844815/124604249-b4401200-dea5-11eb-9d28-c788ebba8ec0.png)

New 클릭
![new](https://user-images.githubusercontent.com/64844815/124604448-e9e4fb00-dea5-11eb-9d74-1be3507da7cc.png)

ApiKey 선택, Submit 클릭
![api key](https://user-images.githubusercontent.com/64844815/124604549-01bc7f00-dea6-11eb-8058-d30eb0ee871d.png)

New 클릭
![key](https://user-images.githubusercontent.com/64844815/124929922-d79cc580-e03b-11eb-9e64-ad90019dda82.png)


선택하고 Edit
![edit](https://user-images.githubusercontent.com/64844815/124604790-43e5c080-dea6-11eb-87f2-bbf631062395.png)

1년 뒤로 변경, Save
![image](https://user-images.githubusercontent.com/64844815/124604903-5cee7180-dea6-11eb-879e-23517c1b7559.png)

`aws-exports.js`에 다음 코드 추가, Appsync에서 생성한 ApiKey 복붙
```
export const apiKey = 'enter your Key, here';
```

close #41 