### PR TITLE
공지사항 탭을 추가하였습니다.

### DIFF
--- a/client/src/Apollo.ts
+++ b/client/src/Apollo.ts
@@ -32,7 +32,7 @@ const tokenAuthLink = createAuthLink({
 
 const awsLink = ApolloLink.split(
   (operation) => {
-    const publicOperations = ['ListUser', 'ListTeamDashboard'];
+    const publicOperations = ['ListUser', 'ListTeamDashboard', 'ListNotice'];
     return publicOperations.includes(operation.operationName);
   },
   apiAuthLink,

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import NotFound from 'page/NotFound';
 import Home from 'page/Home';
 import Contact from 'page/Contact';
 import Mail from 'page/Mail';
+import Notice from 'page/Notice';
 import { withAuthenticator } from 'aws-amplify-react';
 import { Auth } from 'aws-amplify';
 
@@ -24,26 +25,15 @@ function App() {
     <GlobalThemeProvider>
       <Router>
         <Switch>
-          <Route
-            exact path="/survey"
-            component={withAuthenticator(Survey, false, [<LoginPage />])}
-          />
-          <Route
-            exact path="/result"
-            component={withAuthenticator(Result, false, [<LoginPage />])}
-          />
+          <Route exact path="/survey" component={withAuthenticator(Survey, false, [<LoginPage />])}/>
+          <Route exact path="/result" component={withAuthenticator(Result, false, [<LoginPage />])}/>
           <Route render={(props) => <Home {...props} isLoggedIn={isLoggedIn}></Home>} exact path="/"/>
           <Route exact path="/contact" component={Contact} />
           <Route render={(props) => <TeamDashboard {...props} isLoggedIn={isLoggedIn}></TeamDashboard>} exact path="/dashboard/team"/>
-          <Route
-            exact path="/dashboard/personal"
-            component={PersonalDashboard}
-          />
+          <Route exact path="/dashboard/personal" component={PersonalDashboard}/>
           <Route exact path="/login" component={LoginPage} />
-          <Route
-            exact path="/mail"
-            component={withAuthenticator(Mail, false, [<LoginPage />])}
-          />
+          <Route exact path="/notice" component={Notice} />
+          <Route exact path="/mail" component={withAuthenticator(Mail, false, [<LoginPage />])}/>
           <Route path="*" component={NotFound} />
         </Switch>
       </Router>

--- a/client/src/component/molecules/DetailContent/index.tsx
+++ b/client/src/component/molecules/DetailContent/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as S from './style';
 
 interface IDetailContent {
-  title: string;
+  title?: string;
   children: any;
   className?: string;
 }

--- a/client/src/component/orgamisms/DetailModal/Notice/index.stories.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import GlobalThemeProvider from 'style/GlobalThemeProvider';
+import NoticeDetailModal from '.';
+
+const props = {
+  data: {
+    id: 'test',
+    date: '1995-02-13',
+    title: 'test title',
+    contents: 'test contents',
+  },
+  isAdmin: true,
+  onCloseModal: () => alert('close'),
+};
+
+export default {
+  title: 'Organisms/DetailModal/Notice',
+  component: NoticeDetailModal,
+};
+
+export function Default() {
+  return (
+    <GlobalThemeProvider>
+      <NoticeDetailModal {...props} />
+    </GlobalThemeProvider>
+  );
+}

--- a/client/src/component/orgamisms/DetailModal/Notice/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.tsx
@@ -21,7 +21,7 @@ export interface NoticeModalProps {
 const NoticeDetailModal = ({
   className, data, isAdmin, onCloseModal,
 }: NoticeModalProps) => {
-  const { data: noticeData, refetch } = useQuery(
+  const { refetch } = useQuery(
     gql`
       ${listNotice}
     `,

--- a/client/src/component/orgamisms/DetailModal/Notice/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.tsx
@@ -67,13 +67,13 @@ const MailDetailModal = ({
       );
     }
     return (
-      <S.SubmitButton size="medium" color="red" onClick={() => { onCloseModal(); }}>
+      <S.SubmitButton size="medium" color="red" onClick={onCloseModal}>
         닫기
       </S.SubmitButton>
     );
   };
 
-  return data && (
+  return data ? (
     <>
       <DetailModalTemplate
         modalHeader={modalHeader()}
@@ -89,6 +89,8 @@ const MailDetailModal = ({
         />
       )}
     </>
+  ) : (
+    <div>error</div>
   );
 };
 

--- a/client/src/component/orgamisms/DetailModal/Notice/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.tsx
@@ -8,7 +8,7 @@ import * as S from '../style';
 
 export interface NoticeModalProps {
   className?: string;
-  data: {
+  data?: {
     id: string;
     title: string;
     date: string;
@@ -18,7 +18,7 @@ export interface NoticeModalProps {
   onCloseModal: () => void;
 }
 
-const MailDetailModal = ({
+const NoticeDetailModal = ({
   className, data, isAdmin, onCloseModal,
 }: NoticeModalProps) => {
   const { data: noticeData, refetch } = useQuery(
@@ -38,13 +38,13 @@ const MailDetailModal = ({
   const [confirmFunction, setConfirmFunction] = useState<any>(() => {});
   const modalHeader = () => (
     <>
-      <S.Title type='personal'>{data.title}</S.Title>
-      <S.Desc>{data.date}</S.Desc>
+      <S.Title type='personal'>{data?.title}</S.Title>
+      <S.Desc>{data?.date}</S.Desc>
     </>
   );
 
   const renderContents = () => (
-    <S.Paragraph>{data.contents}</S.Paragraph>
+    <S.Paragraph>{data?.contents}</S.Paragraph>
   );
 
   const openModal = () => {
@@ -108,4 +108,4 @@ const MailDetailModal = ({
   );
 };
 
-export default MailDetailModal;
+export default NoticeDetailModal;

--- a/client/src/component/orgamisms/DetailModal/Notice/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.tsx
@@ -55,7 +55,21 @@ const MailDetailModal = ({
   };
 
   const onClickDelete = () => {
-    console.log('sth');
+    const confirmDelete = async () => {
+      await deleteNoticeData({
+        variables: {
+          input: {
+            id: data?.id,
+          },
+        },
+      });
+      await refetch();
+      onCloseModal();
+      closeModal();
+    };
+    openModal();
+    setConfirmText('확인을 누르면 공지가 삭제됩니다.');
+    setConfirmFunction(() => confirmDelete);
   };
 
   const modalButton = () => {

--- a/client/src/component/orgamisms/DetailModal/Notice/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.tsx
@@ -81,7 +81,7 @@ const NoticeDetailModal = ({
       );
     }
     return (
-      <S.SubmitButton size="medium" color="red" onClick={onCloseModal}>
+      <S.SubmitButton size="medium" color="yellow" onClick={onCloseModal}>
         닫기
       </S.SubmitButton>
     );

--- a/client/src/component/orgamisms/DetailModal/Notice/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { listNotice } from 'graphql/queries';
+import { deleteNotice } from 'graphql/mutations';
+import { gql, useQuery, useMutation } from '@apollo/client';
+import ConfirmModal from 'component/orgamisms/ConfirmModal';
+import DetailModalTemplate from '../template';
+import * as S from '../style';
+
+export interface NoticeModalProps {
+  className?: string;
+  data: {
+    id: string;
+    title: string;
+    date: string;
+    contents: string;
+  };
+  isAdmin: boolean;
+  onCloseModal: () => void;
+}
+
+const MailDetailModal = ({
+  className, data, isAdmin, onCloseModal,
+}: NoticeModalProps) => {
+  const { data: noticeData, refetch } = useQuery(
+    gql`
+      ${listNotice}
+    `,
+  );
+
+  const [deleteNoticeData] = useMutation(
+    gql`
+      ${deleteNotice}
+    `,
+  );
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState<string>('');
+  const [confirmFunction, setConfirmFunction] = useState<any>(() => {});
+  const modalHeader = () => (
+    <>
+      <S.Title type='personal'>{data.title}</S.Title>
+      <S.Desc>{data.date}</S.Desc>
+    </>
+  );
+
+  const renderContents = () => (
+    <S.Paragraph>{data.contents}</S.Paragraph>
+  );
+
+  const openModal = () => {
+    setModalOpen(true);
+  };
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+
+  const onClickDelete = () => {
+    console.log('sth');
+  };
+
+  const modalButton = () => {
+    if (isAdmin) {
+      return (
+        <S.SubmitButton size="medium" color="red" onClick={onClickDelete}>
+          메시지 삭제
+        </S.SubmitButton>
+      );
+    }
+    return (
+      <S.SubmitButton size="medium" color="red" onClick={() => { onCloseModal(); }}>
+        닫기
+      </S.SubmitButton>
+    );
+  };
+
+  return data && (
+    <>
+      <DetailModalTemplate
+        modalHeader={modalHeader()}
+        modalBody={renderContents()}
+        modalButton={modalButton()}
+        onCloseModal={onCloseModal}
+      />
+      {modalOpen && (
+        <ConfirmModal
+          text={confirmText}
+          close={closeModal}
+          onClickConfirm={confirmFunction}
+        />
+      )}
+    </>
+  );
+};
+
+export default MailDetailModal;

--- a/client/src/component/orgamisms/DetailModal/Notice/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Notice/index.tsx
@@ -76,7 +76,7 @@ const NoticeDetailModal = ({
     if (isAdmin) {
       return (
         <S.SubmitButton size="medium" color="red" onClick={onClickDelete}>
-          메시지 삭제
+          공지 삭제
         </S.SubmitButton>
       );
     }

--- a/client/src/component/orgamisms/DetailModal/NoticeAddForm/index.stories.tsx
+++ b/client/src/component/orgamisms/DetailModal/NoticeAddForm/index.stories.tsx
@@ -1,0 +1,32 @@
+import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
+import React from 'react';
+import GlobalThemeProvider from 'style/GlobalThemeProvider';
+import NoticeAddForm from '.';
+
+const props = {
+  onCloseModal: () => alert('close'),
+};
+
+export default {
+  title: 'Organisms/DetailModal/NoticeAddForm',
+  component: NoticeAddForm,
+  decorators: [
+    (story: Function) => (
+      <ApolloProvider
+        client={
+          new ApolloClient({ link: undefined, cache: new InMemoryCache() })
+        }
+      >
+        {story()}
+      </ApolloProvider>
+    ),
+  ],
+};
+
+export function Default() {
+  return (
+    <GlobalThemeProvider>
+      <NoticeAddForm {...props} />
+    </GlobalThemeProvider>
+  );
+}

--- a/client/src/component/orgamisms/DetailModal/NoticeAddForm/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/NoticeAddForm/index.tsx
@@ -8,7 +8,13 @@ import * as S from '../style';
 interface InputState {
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  reset?: () => void;
+}
+
+interface ContentsState {
+  value: string;
+  onChange: (
+    event: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => void;
 }
 
 const NoticeAddForm = ({ onCloseModal }: any) => {
@@ -22,10 +28,13 @@ const NoticeAddForm = ({ onCloseModal }: any) => {
       ${listNotice}
     `,
   );
+
+  const dateObj = new Date();
+  const today = `${dateObj.getFullYear()} - ${dateObj.getMonth() + 1} - ${dateObj.getDate()}`;
   // Data to submit when create a team
-  const [title, setTitle] = useState('');
-  const [date, setDate] = useState('');
-  const [contents, setContents] = useState('');
+  const [title, setTitle] = useState<string>('');
+  const [date, setDate] = useState<string>(today);
+  const [contents, setContents] = useState<string>('');
 
   const inputsState: { [key: string]: InputState } = {
     title: {
@@ -40,11 +49,18 @@ const NoticeAddForm = ({ onCloseModal }: any) => {
         setDate(event.target.value);
       },
     },
-    contents: {
-      value: contents,
-      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
-        setContents(event.target.value);
-      },
+  };
+
+  const contentsState: ContentsState = {
+    value: contents,
+    onChange: (
+      event: React.ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      const { target } = event;
+      // Change height of Textarea automatically by value;
+      target.style.height = 'auto';
+      target.style.height = `${target.scrollHeight}px`;
+      setContents(event.target.value);
     },
   };
 
@@ -54,7 +70,9 @@ const NoticeAddForm = ({ onCloseModal }: any) => {
         value={inputsState.title.value}
         placeholder="제목"
         autoWidth
-        maxWidth={300}
+        maxLength={30}
+        minWidth={4}
+        maxWidth={350}
         onChange={inputsState.title.onChange}
       />
       <S.OutlineInput
@@ -68,7 +86,7 @@ const NoticeAddForm = ({ onCloseModal }: any) => {
     </>
   );
 
-  const blockContents = () => {
+  const bodyContents = () => {
     const ref = useRef<HTMLTextAreaElement>(null);
 
     useEffect(() => {
@@ -83,10 +101,11 @@ const NoticeAddForm = ({ onCloseModal }: any) => {
       <S.ContentItem>
         <S.BlockContent className="ci-block">
           <S.Textarea
+            placeholder="내용"
             inputRef={ref}
             type="textarea"
-            value={inputsState.contents.value}
-            onChange={inputsState.contents.onChange}
+            value={contentsState.value}
+            onChange={contentsState.onChange}
           />
         </S.BlockContent>
       </S.ContentItem>
@@ -94,6 +113,9 @@ const NoticeAddForm = ({ onCloseModal }: any) => {
   };
 
   const onMake = async () => {
+    console.log(title);
+    console.log(date);
+    console.log(contents);
     await createNoticeData({
       variables: {
         input: {
@@ -111,11 +133,11 @@ const NoticeAddForm = ({ onCloseModal }: any) => {
     <>
       <DetailModalTemplate
         modalHeader={headerContents}
-        modalBody={<S.ContentsList>{blockContents}</S.ContentsList>}
+        modalBody={bodyContents()}
         modalButton={
           <>
             <S.SubmitButton size="medium" color="yellow" onClick={onMake}>
-              팀 생성하기
+              공지 추가하기
             </S.SubmitButton>
             <S.SpaceSpan />
             <S.SubmitButton size="medium" color="red" onClick={onCloseModal}>

--- a/client/src/component/orgamisms/DetailModal/NoticeAddForm/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/NoticeAddForm/index.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { listNotice } from 'graphql/queries';
+import { createNotice } from 'graphql/mutations';
+import { gql, useMutation, useQuery } from '@apollo/client';
+import DetailModalTemplate from '../template';
+import * as S from '../style';
+
+interface InputState {
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  reset?: () => void;
+}
+
+const NoticeAddForm = ({ onCloseModal }: any) => {
+  const [createNoticeData] = useMutation(
+    gql`
+      ${createNotice}
+    `,
+  );
+  const { refetch } = useQuery(
+    gql`
+      ${listNotice}
+    `,
+  );
+  // Data to submit when create a team
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+  const [contents, setContents] = useState('');
+
+  const inputsState: { [key: string]: InputState } = {
+    title: {
+      value: title,
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+        setTitle(event.target.value);
+      },
+    },
+    date: {
+      value: date,
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+        setDate(event.target.value);
+      },
+    },
+    contents: {
+      value: contents,
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+        setContents(event.target.value);
+      },
+    },
+  };
+
+  const headerContents = (
+    <>
+      <S.TitleInput
+        value={inputsState.title.value}
+        placeholder="제목"
+        autoWidth
+        maxWidth={300}
+        onChange={inputsState.title.onChange}
+      />
+      <S.OutlineInput
+        value={inputsState.date.value}
+        placeholder="날짜"
+        autoWidth
+        minWidth={4}
+        maxWidth={300}
+        onChange={inputsState.date.onChange}
+      />
+    </>
+  );
+
+  const blockContents = () => {
+    const ref = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+      // initailize height on mounted
+      if (ref.current) {
+        const { scrollHeight, style } = ref.current! as HTMLTextAreaElement;
+        style.height = `${scrollHeight}px`;
+      }
+    }, []);
+
+    return (
+      <S.ContentItem>
+        <S.BlockContent className="ci-block">
+          <S.Textarea
+            inputRef={ref}
+            type="textarea"
+            value={inputsState.contents.value}
+            onChange={inputsState.contents.onChange}
+          />
+        </S.BlockContent>
+      </S.ContentItem>
+    );
+  };
+
+  const onMake = async () => {
+    await createNoticeData({
+      variables: {
+        input: {
+          title,
+          date,
+          contents,
+        },
+      },
+    });
+    await refetch();
+    onCloseModal();
+  };
+
+  return (
+    <>
+      <DetailModalTemplate
+        modalHeader={headerContents}
+        modalBody={<S.ContentsList>{blockContents}</S.ContentsList>}
+        modalButton={
+          <>
+            <S.SubmitButton size="medium" color="yellow" onClick={onMake}>
+              팀 생성하기
+            </S.SubmitButton>
+            <S.SpaceSpan />
+            <S.SubmitButton size="medium" color="red" onClick={onCloseModal}>
+              취소
+            </S.SubmitButton>
+          </>
+        }
+        onCloseModal={onCloseModal}
+      />
+    </>
+  );
+};
+
+export default NoticeAddForm;

--- a/client/src/component/orgamisms/DetailModal/Personal/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Personal/index.tsx
@@ -84,7 +84,7 @@ const PersonalDetailModal = ({ data, onCloseModal }: PersonalModalProps) => {
         setIsInTeam(true);
       }
     });
-  }, []);
+  }, [userData]);
 
   const renderContents = () => {
     const skills = data.question[1].answers?.map((skill: string) => {

--- a/client/src/component/orgamisms/DetailModal/Team/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Team/index.tsx
@@ -75,7 +75,7 @@ const TeamDetailModal = ({
         setIsInTeam(true);
       }
     });
-  }, []);
+  }, [userData]);
 
   const renderContents = () => {
     const skills = data?.skills.map((skill: string) => {

--- a/client/src/component/orgamisms/DetailModal/TeamAddForm/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/TeamAddForm/index.tsx
@@ -280,6 +280,7 @@ const TeamAddForm = ({ data, onCloseModal, onClickUpdate }: TeamModalProps) => {
         value={inputsState.name.value}
         placeholder="팀 이름"
         autoWidth
+        minWidth={4}
         maxWidth={300}
         onChange={inputsState.name.onChange}
       />

--- a/client/src/component/orgamisms/DetailModal/style.ts
+++ b/client/src/component/orgamisms/DetailModal/style.ts
@@ -54,6 +54,7 @@ export const ContentsList = styled.ul`
 `;
 
 export const ContentItem = styled.li`
+  list-style:none;
   &:not(:last-child) .ci-block {
     margin-bottom: 2.5em;
   }

--- a/client/src/component/orgamisms/MenuBar/index.tsx
+++ b/client/src/component/orgamisms/MenuBar/index.tsx
@@ -156,9 +156,7 @@ const MenuBar = ({ className }: any) => {
           {isLoggedIn && (
             <S.MailBriefContainer>
               <BriefItems to="/mail" text="Mail" />
-              <S.MailBriefCount
-                counts={mailCounter === 0 || mailCounter === undefined}
-              >
+              <S.MailBriefCount counts={mailCounter === 0 || mailCounter === undefined}>
                 {mailCounter}
               </S.MailBriefCount>
             </S.MailBriefContainer>

--- a/client/src/component/orgamisms/MenuBar/index.tsx
+++ b/client/src/component/orgamisms/MenuBar/index.tsx
@@ -63,7 +63,7 @@ const MenuBar = ({ className }: any) => {
   const handleSize = () => {
     const newWidth = window.innerWidth;
     setWindowWidth(newWidth);
-    if (newWidth > 600) {
+    if (newWidth > 713) {
       setIsClicked(false);
     }
   };
@@ -145,7 +145,7 @@ const MenuBar = ({ className }: any) => {
           <S.HamburgerSpan></S.HamburgerSpan>
         </S.Hamburger>
       </S.MenuBar>
-      {windowWidth < 600 && (
+      {windowWidth < 713 && (
         <S.HamburgerMenus clicked={isClicked}>
           <BriefItems to="/home" text="Home" />
           <BriefItems to="/dashboard/personal" text="Personal" />

--- a/client/src/component/orgamisms/MenuBar/index.tsx
+++ b/client/src/component/orgamisms/MenuBar/index.tsx
@@ -115,58 +115,27 @@ const MenuBar = ({ className }: any) => {
           </S.MenuItems>
         </S.MenuLeft>
         <S.MenuCenter>
-          <BriefItems
-            clName={isPath === '/' ? 'current' : ''}
-            to="/"
-            text="Home"
-          />
-          <BriefItems
-            clName={isPath === '/dashboard/personal' ? 'current' : ''}
-            to="/dashboard/personal"
-            text="Personal"
-          />
-          <BriefItems
-            clName={isPath === '/dashboard/team' ? 'current' : ''}
-            to="/dashboard/team"
-            text="Team"
-          />
-          <BriefItems
-            clName={isPath === '/survey' ? 'current' : ''}
-            to="/survey"
-            text="Survey"
-          />
-          <BriefItems
-            clName={isPath === '/contact' ? 'current' : ''}
-            to="/contact"
-            text="Contact"
-          />
+          <BriefItems clName={isPath === '/' ? 'current' : ''} to="/" text="Home"/>
+          <BriefItems clName={isPath === '/dashboard/personal' ? 'current' : ''} to="/dashboard/personal" text="Personal"/>
+          <BriefItems clName={isPath === '/dashboard/team' ? 'current' : ''} to="/dashboard/team" text="Team"/>
+          <BriefItems clName={isPath === '/survey' ? 'current' : ''} to="/survey" text="Survey"/>
+          <BriefItems clName={isPath === '/contact' ? 'current' : ''} to="/contact" text="Contact"/>
+          <BriefItems clName={isPath === '/notice' ? 'current' : ''} to="/notice" text="Notice"/>
         </S.MenuCenter>
         <S.MenuRight>
           {isLoggedIn && (
             <S.MailMenu>
-              <S.MailCounter
-                counts={mailCounter === 0 || mailCounter === undefined}
-              >
+              <S.MailCounter counts={mailCounter === 0 || mailCounter === undefined}>
                 {mailCounter}
               </S.MailCounter>
-              <BriefItems
-                clName={isPath === '/mail' ? 'current' : ''}
-                to="/mail"
-                text="Mail"
-              />
+              <BriefItems clName={isPath === '/mail' ? 'current' : ''} to="/mail" text="Mail"/>
             </S.MailMenu>
           )}
           <S.MenuItems>
             {isLoggedIn ? (
-              <S.LoginBtn
-                text="LogOut"
-                onLoginClick={onClickSignOut}
-              ></S.LoginBtn>
+              <S.LoginBtn text="LogOut" onLoginClick={onClickSignOut}/>
             ) : (
-              <S.LoginBtn
-                text="LogIn"
-                onLoginClick={googleLoginOnClick}
-              ></S.LoginBtn>
+              <S.LoginBtn text="LogIn" onLoginClick={googleLoginOnClick}/>
             )}
           </S.MenuItems>
         </S.MenuRight>
@@ -183,6 +152,7 @@ const MenuBar = ({ className }: any) => {
           <BriefItems to="/dashboard/team" text="Team" />
           <BriefItems to="/survey" text="Survey" />
           <BriefItems to="/contact" text="Contact" />
+          <BriefItems to="/notice" text="Notice" />
           {isLoggedIn && (
             <S.MailBriefContainer>
               <BriefItems to="/mail" text="Mail" />

--- a/client/src/component/orgamisms/MenuBar/style.ts
+++ b/client/src/component/orgamisms/MenuBar/style.ts
@@ -14,17 +14,20 @@ export const MenuBar = styled.nav`
   padding: 1.7rem 15rem;
   border-bottom: 0.1rem solid rgb(233, 233, 233);
   z-index: 3;
-  @media screen and (max-width: 1100px) {
+  @media screen and (max-width: 1210px) {
     padding: 1.7rem 10rem;
   }
-  @media screen and (max-width: 1000px) {
-    padding: 1.7rem 7rem;
+  @media screen and (max-width: 1065px) {
+    padding: 1.7rem 4rem;
   }
-  @media screen and (max-width: 920px) {
+  @media screen and (max-width: 990px) {
+    padding: 1.7rem 2rem;
+  }
+  @media screen and (max-width: 940px) {
+    padding: 1.7rem 0;
+  }
+  @media screen and (max-width: 713px) {
     padding: 1.7rem 3rem;
-  }
-  @media screen and (max-width: 840px) {
-    padding: 1.7rem 1rem;
   }
 `;
 
@@ -145,7 +148,7 @@ export const MenuRight = styled.ul`
   & a:hover::after {
     background-size: 100% 2rem;
   }
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: 713px) {
     display: none;
   }
 `;
@@ -192,8 +195,18 @@ export const MenuCenter = styled.ul`
   & li:first-child {
     margin-left: 0;
   }
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: 713px) {
     display: none;
+  }
+  @media screen and (max-width: 900px) {
+    & li {
+      margin-left: 3rem;
+    }
+  }
+  @media screen and (max-width: 800px) {
+    & li {
+      margin-left: 1rem;
+    }
   }
 `;
 export const MailMenu = styled.div`
@@ -301,7 +314,7 @@ export const Hamburger = styled.div`
   & span:last-child {
     ${lastSpanStyle}
   }
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: 713px) {
     display: block;
   }
 `;
@@ -321,7 +334,7 @@ export const HamburgerMenus = styled.ul`
   backdrop-filter: blur(5px);
   position: absolute;
   top: 7rem;
-  left: -600px;
+  left: -713px;
   width: 100%;
   z-index: 20;
   & a:hover,

--- a/client/src/graphql/mutations.ts
+++ b/client/src/graphql/mutations.ts
@@ -102,3 +102,22 @@ export const deleteTeam = /* GraphQL */ `
     }
   }
 `;
+
+export const createNotice = /* GraphQL */ `
+  mutation createNotice($input: CreateNoticeInput!) {
+    createNotice(input: $input) {
+      id
+      title
+      contents
+      date
+    }
+  }
+`;
+
+export const deleteNotice = /* GraphQL */ `
+  mutation deleteNotice($input: DeleteNoticeInput!) {
+    deleteNotice(input: $input) {
+      id
+    }
+  }
+`;

--- a/client/src/graphql/queries.ts
+++ b/client/src/graphql/queries.ts
@@ -36,6 +36,7 @@ export const getUser = /* GraphQL */ `
         id
         haveTeam
         surveyCompleted
+        owner
         question {
           title
           answers
@@ -67,6 +68,7 @@ export const getUserById = /* GraphQL */ `
         answers
       }
       personState
+      owner
       teamList {
         id
         name
@@ -150,6 +152,20 @@ export const getTeamDashboard = /* GraphQL */ `
         title
         text
       }
+    }
+  }
+`;
+
+export const listNotice = /* GraphQL */ `
+  query ListNotice($nextToken: String) {
+    listNotice(nextToken: $nextToken) {
+      items {
+        id
+        title
+        contents
+        date
+      }
+      nextToken
     }
   }
 `;

--- a/client/src/page/Home/index.tsx
+++ b/client/src/page/Home/index.tsx
@@ -26,8 +26,8 @@ const Home = ({ className, isLoggedIn }: any) => {
       );
     }
   }
-  // 7월 13일 초대 주소 get, 30일 마다 갱신
-  const slackInvite = 'https://join.slack.com/t/w1616672168-iqi184162/shared_invite/zt-sqrkwn93-SsuQ0qY1xwind4cZ1xfUWw';
+  // 8월 13일 초대 주소 get, 30일 마다 갱신
+  const slackInvite = 'https://join.slack.com/t/w1616672168-iqi184162/shared_invite/zt-ui5ttkrl-6tbTUii60lCkQNntxHSKqg';
 
   const SettingPhase = () => {
     let phase = <></>;

--- a/client/src/page/Mail/index.tsx
+++ b/client/src/page/Mail/index.tsx
@@ -49,6 +49,7 @@ const Mail = ({ className }: any) => {
     );
   });
 
+  console.log(mailList.length);
   const renderModal = () => {
     const onCloseModal = () => setModal({});
 
@@ -65,7 +66,7 @@ const Mail = ({ className }: any) => {
         <S.Top>
           <S.Main>메시지 보관함</S.Main>
         </S.Top>
-        <S.MailList>{mailList}</S.MailList>
+        <S.MailList>{mailList.length === 0 ? '메일함이 비어있습니다.' : mailList}</S.MailList>
       </S.Container>
     </BaseTemplate>
   );

--- a/client/src/page/Mail/index.tsx
+++ b/client/src/page/Mail/index.tsx
@@ -49,7 +49,6 @@ const Mail = ({ className }: any) => {
     );
   });
 
-  console.log(mailList.length);
   const renderModal = () => {
     const onCloseModal = () => setModal({});
 

--- a/client/src/page/Notice/index.tsx
+++ b/client/src/page/Notice/index.tsx
@@ -35,15 +35,12 @@ const Mail = ({ className }: any) => {
       ${listNotice}
     `,
   );
-  const CheckIsAdmin = useCallback(() => {
+  useEffect(() => {
     const admin = ['google_106151528337997471500', 'google_105106168339038633380', 'google_116436995621806622506'];
     if (admin.includes(data?.getUser.items[0].owner)) {
       setIsAdmin(true);
     }
   }, [data]);
-  useEffect(() => {
-    CheckIsAdmin();
-  }, [CheckIsAdmin]);
   if (loading) {
     return <></>;
   }

--- a/client/src/page/Notice/index.tsx
+++ b/client/src/page/Notice/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import BaseTemplate from 'page/BaseTemplate';
 import { createNotice } from 'graphql/mutations';
 import { getUser, listNotice } from 'graphql/queries';
@@ -30,24 +30,24 @@ const Mail = ({ className }: any) => {
     `,
   );
 
-  const admin = ['google_106151528337997471500', 'google_105106168339038633380', 'google_116436995621806622506'];
-    
-  useEffect(() => {
-    if (admin.includes(data?.getUser.items[0].owner)) {
-      setIsAdmin(true);
-      console.log(admin.includes(data.getUser.items[0].owner));
-    }
-  }, [!loading]);
-
   const { loading, data: noticeData } = useQuery(
     gql`
       ${listNotice}
     `,
   );
-
+  const CheckIsAdmin = useCallback(() => {
+    const admin = ['google_106151528337997471500', 'google_105106168339038633380', 'google_116436995621806622506'];
+    if (admin.includes(data?.getUser.items[0].owner)) {
+      setIsAdmin(true);
+    }
+  }, [data]);
+  useEffect(() => {
+    CheckIsAdmin();
+  }, [CheckIsAdmin]);
   if (loading) {
     return <></>;
   }
+
   const { items } = noticeData?.listNotice;
   const NoticeList = items.map((el: any) => (
     <S.List key={el.id} onClick={() => setModal({ data: el })}>

--- a/client/src/page/Notice/index.tsx
+++ b/client/src/page/Notice/index.tsx
@@ -10,11 +10,11 @@ type ExtractType<O, K> = K extends keyof O ? O[K] : never;
 type UserData = ExtractType<NoticeModalProps, 'data'>;
 
 interface ModalState {
-  type?: 'detail';
+  type?: 'detail' | 'add';
   data?: UserData;
 }
 
-const Mail = ({ className }: any) => {
+const Notice = ({ className }: any) => {
   const [modal, setModal] = useState<ModalState>({});
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
@@ -47,7 +47,7 @@ const Mail = ({ className }: any) => {
 
   const { items } = noticeData?.listNotice;
   const NoticeList = items.map((el: any) => (
-    <S.List key={el.id} onClick={() => setModal({ data: el })}>
+    <S.List key={el.id} onClick={() => setModal({ type: 'detail', data: el })}>
       <S.Title>{el.title}</S.Title>
       <S.Text>{el.date}</S.Text>
     </S.List>
@@ -56,15 +56,28 @@ const Mail = ({ className }: any) => {
   const renderModal = () => {
     const onCloseModal = () => setModal({});
 
-    return (
-      modal.data && (
-        <NoticeDetailModal isAdmin={isAdmin} data={modal.data} onCloseModal={onCloseModal} />
-      )
-    );
+    switch (modal?.type) {
+    case 'detail':
+      return (
+        <NoticeDetailModal
+          isAdmin={isAdmin}
+          data={modal.data}
+          onCloseModal={onCloseModal}
+        />
+      );
+    case 'add':
+      return (
+        <TeamAddForm
+          onCloseModal={onCloseModal}
+        />
+      );
+    default:
+      return '';
+    }
   };
 
   const makeNotice = () => {
-    console.log('make');
+    setModal({ type: 'add' });
   };
 
   return (
@@ -82,4 +95,4 @@ const Mail = ({ className }: any) => {
   );
 };
 
-export default Mail;
+export default Notice;

--- a/client/src/page/Notice/index.tsx
+++ b/client/src/page/Notice/index.tsx
@@ -4,6 +4,7 @@ import { createNotice } from 'graphql/mutations';
 import { getUser, listNotice } from 'graphql/queries';
 import { gql, useQuery, useMutation } from '@apollo/client';
 import NoticeDetailModal, { NoticeModalProps } from 'component/orgamisms/DetailModal/Notice';
+import NoticeAddForm from 'component/orgamisms/DetailModal/NoticeAddForm';
 import * as S from './style';
 
 type ExtractType<O, K> = K extends keyof O ? O[K] : never;
@@ -67,7 +68,7 @@ const Notice = ({ className }: any) => {
       );
     case 'add':
       return (
-        <TeamAddForm
+        <NoticeAddForm
           onCloseModal={onCloseModal}
         />
       );
@@ -76,7 +77,7 @@ const Notice = ({ className }: any) => {
     }
   };
 
-  const makeNotice = () => {
+  const onClickmakeNotice = () => {
     setModal({ type: 'add' });
   };
 
@@ -88,7 +89,7 @@ const Notice = ({ className }: any) => {
         </S.Top>
         <S.NoticeList>{NoticeList}</S.NoticeList>
         {isAdmin && (
-          <S.CreateBtn onClick={makeNotice}>공지 추가하기</S.CreateBtn>
+          <S.CreateBtn onClick={onClickmakeNotice}>공지 추가하기</S.CreateBtn>
         )}
       </S.Container>
     </BaseTemplate>

--- a/client/src/page/Notice/index.tsx
+++ b/client/src/page/Notice/index.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import BaseTemplate from 'page/BaseTemplate';
-import { createNotice } from 'graphql/mutations';
 import { getUser, listNotice } from 'graphql/queries';
-import { gql, useQuery, useMutation } from '@apollo/client';
+import { gql, useQuery } from '@apollo/client';
 import NoticeDetailModal, { NoticeModalProps } from 'component/orgamisms/DetailModal/Notice';
 import NoticeAddForm from 'component/orgamisms/DetailModal/NoticeAddForm';
 import * as S from './style';
@@ -22,12 +21,6 @@ const Notice = ({ className }: any) => {
   const { data } = useQuery(
     gql`
       ${getUser}
-    `,
-  );
-
-  const [createNoticeData] = useMutation(
-    gql`
-      ${createNotice}
     `,
   );
 

--- a/client/src/page/Notice/index.tsx
+++ b/client/src/page/Notice/index.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import BaseTemplate from 'page/BaseTemplate';
+import { createNotice } from 'graphql/mutations';
+import { getUser, listNotice } from 'graphql/queries';
+import { gql, useQuery, useMutation } from '@apollo/client';
+import NoticeDetailModal, { NoticeModalProps } from 'component/orgamisms/DetailModal/Notice';
+import * as S from './style';
+
+type ExtractType<O, K> = K extends keyof O ? O[K] : never;
+type UserData = ExtractType<NoticeModalProps, 'data'>;
+
+interface ModalState {
+  type?: 'detail';
+  data?: UserData;
+}
+
+const Mail = ({ className }: any) => {
+  const [modal, setModal] = useState<ModalState>({});
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+
+  const { data } = useQuery(
+    gql`
+      ${getUser}
+    `,
+  );
+
+  const [createNoticeData] = useMutation(
+    gql`
+      ${createNotice}
+    `,
+  );
+
+  const admin = ['google_106151528337997471500', 'google_105106168339038633380', 'google_116436995621806622506'];
+    
+  useEffect(() => {
+    if (admin.includes(data?.getUser.items[0].owner)) {
+      setIsAdmin(true);
+      console.log(admin.includes(data.getUser.items[0].owner));
+    }
+  }, [!loading]);
+
+  const { loading, data: noticeData } = useQuery(
+    gql`
+      ${listNotice}
+    `,
+  );
+
+  if (loading) {
+    return <></>;
+  }
+  const { items } = noticeData?.listNotice;
+  const NoticeList = items.map((el: any) => (
+    <S.List key={el.id} onClick={() => setModal({ data: el })}>
+      <S.Title>{el.title}</S.Title>
+      <S.Text>{el.date}</S.Text>
+    </S.List>
+  ));
+
+  const renderModal = () => {
+    const onCloseModal = () => setModal({});
+
+    return (
+      modal.data && (
+        <NoticeDetailModal isAdmin={isAdmin} data={modal.data} onCloseModal={onCloseModal} />
+      )
+    );
+  };
+
+  const makeNotice = () => {
+    console.log('make');
+  };
+
+  return (
+    <BaseTemplate Modal={renderModal()} closeModal={() => setModal({})}>
+      <S.Container className={className}>
+        <S.Top>
+          <S.Main>공지 사항</S.Main>
+        </S.Top>
+        <S.NoticeList>{NoticeList}</S.NoticeList>
+        {isAdmin && (
+          <S.CreateBtn onClick={makeNotice}>공지 추가하기</S.CreateBtn>
+        )}
+      </S.Container>
+    </BaseTemplate>
+  );
+};
+
+export default Mail;

--- a/client/src/page/Notice/style.ts
+++ b/client/src/page/Notice/style.ts
@@ -1,0 +1,164 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Top = styled.div`
+  top: 0em;
+  left: 0em;
+  z-index: 2;
+  padding-top: 2em;
+  background-color: #fff;
+  padding-bottom: 2em;
+`;
+
+export const Main = styled.h1`
+  display: flex;
+  margin: 3em 0 1em;
+  justify-content: center;
+  align-items: center;
+  font-size: 3.2em;
+`;
+
+export const CreateBtn = styled.button`
+  cursor: pointer;
+  width: 20rem;
+  height: 6rem;
+  font-size: 2rem;
+  border-radius: 0.5rem;
+`;
+
+export const NoticeList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    width: 1.2rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #7f8c8d;
+    border-radius: 1rem;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: #dfe6e9;
+    border-radius: 1rem;
+  }
+  padding-top: 1em;
+  width: 124rem;
+  height: 68rem;
+  @media screen and (max-width: 1290px) {
+    width: 108rem;
+  }
+  @media screen and (max-width: 1110px) {
+    width: 95rem;
+  }
+  @media screen and (max-width: 954px) {
+    width: 82rem;
+  }
+  @media screen and (max-width: 820px) {
+    width: 67em;
+  }
+  @media screen and (max-width: 670px) {
+    width: 49em;
+  }
+  @media screen and (max-width: 470px) {
+    width: 38em;
+  }
+`;
+
+export const List = styled.div`
+  display: flex;
+  width: 110em;
+  cursor: pointer;
+  margin-bottom: 3em;
+  &:last-child {
+    margin-bottom: 1em;
+  }
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 1.5em;
+  padding: 2em;
+  border: 0.3em solid #ffffff;
+  box-shadow: 0 0.1em 0.3em rgba(0, 0, 0, 0.12),
+    0 0.1em 0.2em rgba(0, 0, 0, 0.24);
+  transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
+  &:hover {
+    box-shadow: 0 1.4em 2.8em rgba(0, 0, 0, 0.25), 0 1em 1em rgba(0, 0, 0, 0.22);
+  }
+  @media screen and (max-width: 1290px) {
+    width: 97em;
+  }
+  @media screen and (max-width: 1110px) {
+    width: 84rem;
+  }
+  @media screen and (max-width: 954px) {
+    width: 71em;
+  }
+  @media screen and (max-width: 820px) {
+    width: 59rem;
+  }
+  @media screen and (max-width: 670px) {
+    width: 43rem;
+    display: flex;
+    flex-direction: column;
+  }
+  @media screen and (max-width: 470px) {
+    width: 36rem;
+  }
+`;
+
+export const Title = styled.h1`
+  font-size: 2em;
+  @media screen and (max-width: 670px) {
+    font-size: 2.5em;
+    margin-bottom: 1.6em;
+  }
+`;
+
+export const Text = styled.div`
+  font-size: 2em;
+`;
+export const Stack = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+export const Stacklist = styled.div`
+  font-size: 2em;
+  margin-right: 0.5em;
+  background-color: #dfe6e9;
+  border-radius: 2em;
+  padding: 0.4em 0.5em;
+`;
+
+export const Team = styled.div`
+  border-radius: 2em;
+  background-color: #e3faf3;
+  padding: 0.7em 0.8em;
+  color: #07c3a7;
+  font-size: 1.6rem;
+  font-weight: bold;
+`;
+
+export const ContentInfo = styled.div`
+  font-size: 1.5rem;
+`;
+
+export const Left = styled.div`
+  width: 123rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const Name = styled.h1`
+  font-size: 3rem;
+`;
+
+export const Content = styled.div`
+  display: flex;
+`;

--- a/client/src/page/Survey/index.tsx
+++ b/client/src/page/Survey/index.tsx
@@ -65,15 +65,7 @@ function Survey() {
           variables: {
             input: {
               question: firstInput,
-              mail: [
-                {
-                  from: 'admin',
-                  teamId:
-                    '안녕하세요 Team Auto Matcher에 오신 것을 환영합니다. Survey 페이지로 이동해 설문을 완료해주시면 개인으로 활동할 수 있습니다. 그 이후에는 팀원으로 활동하시거나, 팀을 등록해 팀장으로 활동하 실 수 있습니다. 더 많은 정보는 slack 혹은 github에서 얻으실 수 있습니다.',
-                  type: 'notice',
-                  teamName: 'Team Auto Matcher',
-                },
-              ],
+              mail: [],
               haveTeam: false,
               surveyCompleted: false,
               personState: '팀 구하는 중',


### PR DESCRIPTION
공지사항을 추가하였습니다. admin 목록을 만들어 목록에 속하는 구글 owner아이디를 갖고 있으면 공지를 추가하고 삭제할 수 있게 했습니다.

![image](https://user-images.githubusercontent.com/71132893/129434766-011ab97d-5499-46da-8752-57a9356f6f99.png)
![image](https://user-images.githubusercontent.com/71132893/129434768-fccc87b7-d17c-4276-ada3-c247525d99f0.png)
![image](https://user-images.githubusercontent.com/71132893/129434774-3744f530-3276-4538-b1f8-e2e64c9e11f3.png)
with login
![image](https://user-images.githubusercontent.com/71132893/129434778-3fcd86e2-a523-45e4-835a-db56ddca985d.png)
without login
![image](https://user-images.githubusercontent.com/71132893/129434780-de607363-fb50-428f-8b12-6475cf247e38.png)


아래부터는 추가해야할 것들입니다.
aws appsync 데이터 원본에서 notice 테이블과 연결해줄 데이터원본을 생성해줍니다.
![image](https://user-images.githubusercontent.com/71132893/129334370-4be4e8c3-e1a7-486a-99fb-321fe2ca88d0.png)
dynamodb에서 notice테이블을 생성해줍니다 기본키와 이름은 다음과 같습니다.
![image](https://user-images.githubusercontent.com/71132893/129334417-517049c0-d746-4d53-9c69-d10c27488e3f.png)
![image](https://user-images.githubusercontent.com/71132893/129334434-dbb34d22-b787-4576-b4c4-6ec63609f8d7.png)

스키마는 notion에 업데이트하겠습니다.

listNotice
![image](https://user-images.githubusercontent.com/71132893/129335530-10b5e862-a3b6-4dd6-8a80-b6801dd72c91.png)
![image](https://user-images.githubusercontent.com/71132893/129335455-3b8646f4-3e79-4a68-88ce-6f906cbcbdb5.png)

```graphql
## Below example shows how to look up an item with a Primary Key of "id" from GraphQL arguments
## The helper $util.dynamodb.toDynamoDBJson automatically converts to a DynamoDB formatted request
## There is a "context" object with arguments, identity, headers, and parent field information you can access.
## It also has a shorthand notation avaialable:
##  - $context or $ctx is the root object
##  - $ctx.arguments or $ctx.args contains arguments
##  - $ctx.identity has caller information, such as $ctx.identity.username
##  - $ctx.request.headers contains headers, such as $context.request.headers.xyz
##  - $ctx.source is a map of the parent field, for instance $ctx.source.xyz
## Read more: https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference.html

{
    "version": "2017-02-28",
    "operation": "Scan",
    ##"key: {
    ##	"id":$util.dynamodb.toDtynamoDBJson($ctx.args.id),
    ## }
}
```

CreateNotice
![image](https://user-images.githubusercontent.com/71132893/129335852-bd61c1c6-9397-4b9c-a07f-8ff1f137f23a.png)
![image](https://user-images.githubusercontent.com/71132893/129434630-f7d24623-fd55-4009-a8cf-cf06c222b4f4.png)


```graphql
## Below example shows how to create an object from all provided GraphQL arguments
## The primary key of the obejct is a randomly generated UUD using the $util.autoId() utility
## Other utilities include $util.matches() for regular expressions, $util.time.nowISO8601() or
##   $util.time.nowEpochMilliSeconds() for timestamps, and even List or Map helpers like
##   $util.list.copyAndRetainAll() $util.map.copyAndRemoveAllKeys() for shallow copies
## Read more: https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html#utility-helpers-in-util

{
    "version" : "2018-05-29",
    "operation" : "PutItem",
    "key" : {
        "id":   $util.dynamodb.toDynamoDBJson($util.autoId())
    },
    "attributeValues" : $util.dynamodb.toMapValuesJson($ctx.args.input)
}
```

DeleteNotice
![image](https://user-images.githubusercontent.com/71132893/129335791-4be9ae0e-5ff9-419c-9747-087bf7816d86.png)

```graphql
{
    "version" : "2017-02-28",
    "operation" : "DeleteItem",
    "key" : {
        ## If your table's hash key is not named 'id', update it here. **
        "id" : { "S" : "${ctx.args.input.id}" }
        ## If your table has a sort key, add it as an item here. **
    }
}
```
close #108 