### PR TITLE
팀 생성할 때, 새로고침되는 현상 수정했습니다.

### DIFF
--- a/client/src/component/orgamisms/DetailModal/TeamAddForm/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/TeamAddForm/index.tsx
@@ -429,7 +429,6 @@ const TeamAddForm = ({ data, onCloseModal, onClickUpdate }: TeamModalProps) => {
         });
         await teamRefetch();
         onCloseModal();
-        history.go(0);
       } else {
         const updateConfirm = async () => {
           const removeType = contents.map((el: any) => ({

--- a/client/src/page/Dashboard/Team/index.tsx
+++ b/client/src/page/Dashboard/Team/index.tsx
@@ -25,7 +25,6 @@ const TeamDashboardPage = ({ className, isLoggedIn }: any) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [confirmText, setConfirmText] = useState<string>('');
   const [confirmFunction, setConfirmFunction] = useState<any>(() => {});
-
   const { data: userData } = useQuery(
     gql`
       ${getUser}
@@ -38,18 +37,11 @@ const TeamDashboardPage = ({ className, isLoggedIn }: any) => {
     `,
   );
 
-  const { data: teamData } = useQuery(
+  const { refetch } = useQuery(
     gql`
       ${getTeamDashboard}
     `,
-    {
-      variables: {
-        id:
-          userData && userData.getUser.items?.length !== 0
-            ? userData.getUser.items[0].id
-            : '',
-      },
-    },
+    { skip: !userData?.getUser.items[0].id },
   );
 
   if (loading) {
@@ -98,11 +90,12 @@ const TeamDashboardPage = ({ className, isLoggedIn }: any) => {
   const renderModal = () => {
     const onCloseModal = () => setModal({});
 
-    const onClickUpdate = () => {
+    const onClickUpdate = async () => {
+      const res = await refetch({ id: userData.getUser.items[0].id });
       if (modal?.type === 'update') {
-        setModal({ type: 'detail', data: teamData.getTeamDashboard });
+        setModal({ type: 'detail', data: res?.data.getTeamDashboard });
       } else {
-        setModal({ type: 'update', data: teamData.getTeamDashboard });
+        setModal({ type: 'update', data: res?.data.getTeamDashboard });
       }
     };
 
@@ -136,13 +129,14 @@ const TeamDashboardPage = ({ className, isLoggedIn }: any) => {
   };
 
   const ClickerLoad = () => {
-    if (teamData && userData) {
+    if (userData) {
       if (userData.getUser.items[0].haveTeam) {
         return (
           <Team.FloatingButton
-            onClick={() =>
-              setModal({ type: 'detail', data: teamData.getTeamDashboard })
-            }
+            onClick={async () => {
+              const res = await refetch({ id: userData.getUser.items[0].id });
+              setModal({ type: 'detail', data: res?.data.getTeamDashboard });
+            }}
           >
             나의 팀
           </Team.FloatingButton>


### PR DESCRIPTION
내 팀 버튼을 누를 때, 데이터를 가져옴으로써 빈창이 나타나는 현상을 수정했습니다.  

before -   
![image](https://user-images.githubusercontent.com/71132893/130740718-f21c5386-037f-4fb5-b8eb-929adf10358b.png)  

after -  
![image](https://user-images.githubusercontent.com/71132893/130740575-4058f4cf-9544-4b2c-a585-a99785285c95.png)  

원래는 useLazyQuery를 통해서, 비동기처리를 통해서 데이터를 가져온 후 화면에 나타내도록 하려고 했습니다.  
하지만 현재 useLazyQuery는 promise를 리턴하지 않기때문에 비동기처리를 하지 못했습니다.  
참조 : [apollo github](https://github.com/apollographql/react-apollo/issues/3499)  

대안으로 refetch를 통해 variable을 설정해줄 수 있다고 해서, 사용했습니다.
참조 : [StackOverflow](https://stackoverflow.com/questions/62122523/wait-for-uselazyquery-response)
