### PR TITLE
git api limit 해제

### DIFF
--- a/client/src/component/orgamisms/DetailModal/Team/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Team/index.tsx
@@ -34,6 +34,9 @@ const TeamDetailModal = ({
   // github API
   const api = axios.create({
     baseURL: `https://api.github.com/repos/LM-channel-team-project/${data?.reponame}`,
+    headers: {
+      Authorization: process.env.REACT_APP_GIT_APIKEY,
+    },
   });
 
   type GitApiType = {


### PR DESCRIPTION
github api 요청을 기본적으로 시간당 60번만 호출 할 수 있어서 60번을 다 호출하면 설정한 api 정보가 뜨지 않기 때문에

github의 person access tokens을 이용하여 시간당 5000번 호출 할 수 있게 설정 하였습니다.

