### PR TITLE
팀페이지의 팀장명 혹은 개인의 팀명이 잘못 뜨는 현상을 수정했습니다.

### DIFF
--- a/client/src/component/orgamisms/DetailModal/Personal/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Personal/index.tsx
@@ -6,6 +6,7 @@ import {
   getTeamDashboard,
   listUser,
 } from 'graphql/queries';
+import makeTeamIdByUserId from 'utils/setTeamId';
 import { useHistory } from 'react-router-dom';
 import ConfirmModal from 'component/orgamisms/ConfirmModal';
 import { gql, useQuery, useMutation } from '@apollo/client';
@@ -52,10 +53,9 @@ const PersonalDetailModal = ({ data, onCloseModal }: PersonalModalProps) => {
       ${getTeamDashboard}
     `,
     {
-      variables: { id: userData && userData.getUser.items[0]?.id },
+      variables: { id: userData && makeTeamIdByUserId(userData.getUser.items[0]?.id) },
     },
   );
-
   const [updateUserData] = useMutation(
     gql`
       ${updateUser}
@@ -82,7 +82,7 @@ const PersonalDetailModal = ({ data, onCloseModal }: PersonalModalProps) => {
 
   useEffect(() => {
     data?.teamList.forEach((el: any) => {
-      if (el.id === userData?.getUser.items[0]?.id) {
+      if (el.id === makeTeamIdByUserId(userData.getUser.items[0]?.id)) {
         setIsInTeam(true);
       }
     });
@@ -304,7 +304,7 @@ const PersonalDetailModal = ({ data, onCloseModal }: PersonalModalProps) => {
       const userItems = userData?.getUser.items[0];
       const teamFilter = data?.teamList
         .filter((el: any) => {
-          if (el.id === userItems.id) {
+          if (el.id === makeTeamIdByUserId(userItems.id)) {
             return false;
           }
           return true;
@@ -335,7 +335,7 @@ const PersonalDetailModal = ({ data, onCloseModal }: PersonalModalProps) => {
       await updateTeamData({
         variables: {
           input: {
-            id: userItems.id,
+            id: makeTeamIdByUserId(userItems.id),
             people: peopleFilter,
           },
         },

--- a/client/src/component/orgamisms/DetailModal/Team/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/Team/index.tsx
@@ -442,7 +442,7 @@ const TeamDetailModal = ({
       await deleteTeamData({
         variables: {
           input: {
-            id: data?.owner,
+            id: data?.id,
           },
         },
       });

--- a/client/src/component/orgamisms/DetailModal/TeamAddForm/index.tsx
+++ b/client/src/component/orgamisms/DetailModal/TeamAddForm/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { skillsLabel } from 'style/preset';
 import { Item } from 'component/orgamisms/AutoCompleteList';
+import makeTeamIdByUserId from 'utils/setTeamId';
 import { getUser, listTeamDashboard } from 'graphql/queries';
 import { createTeam, updateUser, updateTeam } from 'graphql/mutations';
 import { gql, useMutation, useQuery } from '@apollo/client';
@@ -402,7 +403,7 @@ const TeamAddForm = ({ data, onCloseModal, onClickUpdate }: TeamModalProps) => {
         await createTeamData({
           variables: {
             input: {
-              id: userItems.id,
+              id: makeTeamIdByUserId(userItems.id),
               name,
               people: [
                 { id: userItems.id, name: userItems.question[11].answers[0] },
@@ -424,7 +425,7 @@ const TeamAddForm = ({ data, onCloseModal, onClickUpdate }: TeamModalProps) => {
             input: {
               id: userItems.id,
               haveTeam: true,
-              teamList: [...removeType, { id: userItems.id, name }],
+              teamList: [...removeType, { id: makeTeamIdByUserId(userItems.id), name }],
             },
           },
         });

--- a/client/src/page/Dashboard/Team/index.tsx
+++ b/client/src/page/Dashboard/Team/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { getTeamDashboard, listTeamDashboard, getUser } from 'graphql/queries';
 import { gql, useQuery } from '@apollo/client';
 import * as Personal from 'page/Dashboard/Personal/style';
+import makeTeamIdByUserId from 'utils/setTeamId';
 import BaseTemplate from 'page/BaseTemplate';
 import { useHistory } from 'react-router-dom';
 import ConfirmModal from 'component/orgamisms/ConfirmModal';
@@ -121,7 +122,7 @@ const TeamDashboardPage = ({ className, isLoggedIn }: any) => {
     const onCloseModal = () => setModal({});
 
     const onClickUpdate = async () => {
-      const res = await refetch({ id: userData.getUser.items[0].id });
+      const res = await refetch({ id: makeTeamIdByUserId(userData.getUser.items[0].id) });
       if (modal?.type === 'update') {
         setModal({ type: 'detail', data: res?.data.getTeamDashboard });
       } else {
@@ -164,7 +165,7 @@ const TeamDashboardPage = ({ className, isLoggedIn }: any) => {
         return (
           <Team.FloatingButton
             onClick={async () => {
-              const res = await refetch({ id: userData.getUser.items[0].id });
+              const res = await refetch({ id: makeTeamIdByUserId(userData.getUser.items[0].id) });
               setModal({ type: 'detail', data: res?.data.getTeamDashboard });
             }}
           >

--- a/client/src/utils/setTeamId.tsx
+++ b/client/src/utils/setTeamId.tsx
@@ -1,0 +1,3 @@
+const makeTeamIdByUserId = (id: string) => `${id}0`;
+
+export default makeTeamIdByUserId;


### PR DESCRIPTION
팀명의 id와 팀장의 id가 같아서 발생하는 오류, 팀 명에 '0' 붙여줌으로써 해결했습니다.
머지하면 테스트서버의 DB를, 실서버에 배포할 때는 실서버 DB업데이트 하겠습니다.

close #106 